### PR TITLE
default clause replaced by otherwise clause for metadirective in OpenMP 5.2

### DIFF
--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -1647,6 +1647,10 @@ def err_omp_expected_colon : Error<"missing ':' in %0">;
 def err_omp_missing_comma : Error< "missing ',' after %0">;
 def err_omp_expected_context_selector
     : Error<"expected valid context selector in %0">;
+def err_omp_unknown_clause
+    : Error<"unknown clause '%0' in %1">;
+def warn_omp_default_deprecated : Warning<"'default' clause for"
+  " 'metadirective' is deprecated; use 'otherwise' instead">, InGroup<Deprecated>;
 def err_omp_requires_out_inout_depend_type : Error<
   "reserved locator 'omp_all_memory' requires 'out' or 'inout' "
   "dependency types">;

--- a/clang/lib/Basic/OpenMPKinds.cpp
+++ b/clang/lib/Basic/OpenMPKinds.cpp
@@ -246,6 +246,7 @@ unsigned clang::getOpenMPSimpleClauseType(OpenMPClauseKind Kind, StringRef Str,
   case OMPC_uses_allocators:
   case OMPC_affinity:
   case OMPC_when:
+  case OMPC_otherwise:
   case OMPC_append_args:
     break;
   default:
@@ -580,6 +581,7 @@ const char *clang::getOpenMPSimpleClauseTypeName(OpenMPClauseKind Kind,
   case OMPC_uses_allocators:
   case OMPC_affinity:
   case OMPC_when:
+  case OMPC_otherwise:
   case OMPC_append_args:
     break;
   default:

--- a/clang/lib/Parse/ParseOpenMP.cpp
+++ b/clang/lib/Parse/ParseOpenMP.cpp
@@ -2743,6 +2743,15 @@ StmtResult Parser::ParseOpenMPDeclarativeOrExecutableDirective(
       OpenMPClauseKind CKind = Tok.isAnnotation()
                                    ? OMPC_unknown
                                    : getOpenMPClauseKind(PP.getSpelling(Tok));
+      // Check if the clause is unrecognized.
+      if (CKind == OMPC_unknown) {
+        Diag(Tok, diag::err_omp_unknown_clause)
+        << PP.getSpelling(Tok) << "metadirective";
+        return Directive;
+      }
+      if(CKind == OMPC_default) {
+        Diag(Tok, diag::warn_omp_default_deprecated);
+      }
       SourceLocation Loc = ConsumeToken();
 
       // Parse '('.
@@ -2767,6 +2776,12 @@ StmtResult Parser::ParseOpenMPDeclarativeOrExecutableDirective(
           Diag(Tok, diag::err_omp_expected_colon) << "when clause";
           TPA.Commit();
           return Directive;
+        }
+      }
+      if (CKind == OMPC_otherwise) {
+        // Check for 'otherwise' keyword.
+        if (Tok.is(tok::identifier) && Tok.getIdentifierInfo()->getName() == "otherwise") {
+        ConsumeToken();  // Consume 'otherwise'
         }
       }
       // Skip Directive for now. We will parse directive in the second iteration

--- a/clang/test/OpenMP/metadirective_ast_print.c
+++ b/clang/test/OpenMP/metadirective_ast_print.c
@@ -15,18 +15,18 @@ void bar(void);
 #define N 10
 void foo(void) {
 #pragma omp metadirective when(device = {kind(cpu)} \
-                               : parallel) default()
+                               : parallel) otherwise()
   bar();
 #pragma omp metadirective when(implementation = {vendor(score(0)  \
                                                         : llvm)}, \
                                device = {kind(cpu)}               \
-                               : parallel) default(target teams)
+                               : parallel) otherwise(target teams)
   bar();
 #pragma omp metadirective when(device = {kind(gpu)}                                 \
                                : target teams) when(implementation = {vendor(llvm)} \
-                                                    : parallel) default()
+                                                    : parallel) otherwise()
   bar();
-#pragma omp metadirective default(target) when(implementation = {vendor(score(5)  \
+#pragma omp metadirective otherwise(target) when(implementation = {vendor(score(5)  \
                                                                         : llvm)}, \
                                                device = {kind(cpu, host)}         \
                                                : parallel)
@@ -40,15 +40,15 @@ void foo(void) {
   for (int i = 0; i < 100; i++)
     ;
 #pragma omp metadirective when(implementation = {extension(match_all)} \
-                               : parallel) default(parallel for)
+                               : parallel) otherwise(parallel for)
   for (int i = 0; i < 100; i++)
     ;
 #pragma omp metadirective when(implementation = {extension(match_any)} \
-                               : parallel) default(parallel for)
+                               : parallel) otherwise(parallel for)
   for (int i = 0; i < 100; i++)
     ;
 #pragma omp metadirective when(implementation = {extension(match_none)} \
-                               : parallel) default(parallel for)
+                               : parallel) otherwise(parallel for)
   for (int i = 0; i < 100; i++)
     ;
 
@@ -64,17 +64,17 @@ void foo(void) {
 
 #pragma omp metadirective when(device={arch("amdgcn")}: \
                                 teams distribute parallel for)\
-                                default(parallel for)
+                                otherwise(parallel for)
   for (int i = 0; i < 100; i++)
   ;
 
 #pragma omp metadirective when(implementation = {extension(match_all)} \
-                               : nothing) default(parallel for)
+                               : nothing) otherwise(parallel for)
   for (int i = 0; i < 16; i++)
     ;
 
 #pragma omp metadirective when(implementation = {extension(match_any)} \
-                               : parallel) default(nothing)
+                               : parallel) otherwise(nothing)
   for (int i = 0; i < 16; i++)
     ;
 }

--- a/clang/test/OpenMP/metadirective_device_arch_codegen.cpp
+++ b/clang/test/OpenMP/metadirective_device_arch_codegen.cpp
@@ -27,7 +27,7 @@ int metadirective1() {
    {
       #pragma omp metadirective \
                    when(device={arch("amdgcn")}: teams distribute parallel for) \
-                   default(parallel for)
+                   otherwise(parallel for)
 
          for (int i = 0; i < N; i++) {
 	    #pragma omp atomic write

--- a/clang/test/OpenMP/metadirective_device_isa_codegen.cpp
+++ b/clang/test/OpenMP/metadirective_device_isa_codegen.cpp
@@ -8,7 +8,7 @@ void bar();
 
 void x86_64_device_isa_selected() {
 #pragma omp metadirective when(device = {isa("sse2")} \
-                               : parallel) default(single)
+                               : parallel) otherwise(single)
   bar();
 }
 // CHECK-LABEL: void @_Z26x86_64_device_isa_selectedv()
@@ -21,7 +21,7 @@ void x86_64_device_isa_selected() {
 
 void x86_64_device_isa_not_selected() {
 #pragma omp metadirective when(device = {isa("some-unsupported-feature")} \
-                               : parallel) default(single)
+                               : parallel) otherwise(single)
   bar();
 }
 // CHECK-LABEL: void @_Z30x86_64_device_isa_not_selectedv()

--- a/clang/test/OpenMP/metadirective_device_isa_codegen_amdgcn.cpp
+++ b/clang/test/OpenMP/metadirective_device_isa_codegen_amdgcn.cpp
@@ -15,7 +15,7 @@ int amdgcn_device_isa_selected() {
   {
 #pragma omp metadirective                     \
     when(device = {isa("dpp")} \
-         : parallel) default(single)
+         : parallel) otherwise(single)
     threadCount++;
   }
 
@@ -38,7 +38,7 @@ int amdgcn_device_isa_not_selected() {
     when(device = {isa("sse")}                                 \
          : parallel)                                           \
         when(device = {isa("another-unsupported-gpu-feature")} \
-             : parallel) default(single)
+             : parallel) otherwise(single)
     threadCount++;
   }
 

--- a/clang/test/OpenMP/metadirective_device_kind_codegen.c
+++ b/clang/test/OpenMP/metadirective_device_kind_codegen.c
@@ -30,7 +30,7 @@ void foo(void) {
                                : parallel)
   bar();
 #pragma omp metadirective when(device = {kind(gpu)} \
-                               : target parallel for) default(parallel for)
+                               : target parallel for) otherwise(parallel for)
   for (int i = 0; i < 100; i++)
     ;
 }

--- a/clang/test/OpenMP/metadirective_device_kind_codegen.cpp
+++ b/clang/test/OpenMP/metadirective_device_kind_codegen.cpp
@@ -31,7 +31,7 @@ void foo() {
                                : parallel)
   bar();
 #pragma omp metadirective when(device = {kind(gpu)} \
-                               : target parallel for) default(parallel for)
+                               : target parallel for) otherwise(parallel for)
   for (int i = 0; i < 100; i++)
     ;
 }

--- a/clang/test/OpenMP/metadirective_empty.cpp
+++ b/clang/test/OpenMP/metadirective_empty.cpp
@@ -11,12 +11,12 @@ void func() {
   // Test where a valid when clause contains empty directive.
   // The directive will be ignored and code for a serial for loop will be generated.
 #pragma omp metadirective when(implementation = {vendor(llvm)} \
-                               :) default(parallel for)
+                               :) otherwise(parallel for)
   for (int i = 0; i < N; i++)
     ;
 
 #pragma omp metadirective when(implementation = {vendor(llvm)} \
-                               :nothing) default(parallel for)
+                               :nothing) otherwise(parallel for)
   for (int i = 0; i < N; i++)
     ;
 }

--- a/clang/test/OpenMP/metadirective_implementation_codegen.c
+++ b/clang/test/OpenMP/metadirective_implementation_codegen.c
@@ -12,27 +12,27 @@ void foo(void) {
 #pragma omp metadirective when(implementation = {vendor(score(0)  \
                                                         : llvm)}, \
                                device = {kind(cpu)}               \
-                               : parallel) default(target teams)
+                               : parallel) otherwise(target teams)
   bar();
 #pragma omp metadirective when(device = {kind(gpu)}                                 \
                                : target teams) when(implementation = {vendor(llvm)} \
-                                                    : parallel) default()
+                                                    : parallel) otherwise()
   bar();
-#pragma omp metadirective default(target) when(implementation = {vendor(score(5)  \
+#pragma omp metadirective otherwise(target) when(implementation = {vendor(score(5)  \
                                                                         : llvm)}, \
                                                device = {kind(cpu, host)}         \
                                                : parallel)
   bar();
 #pragma omp metadirective when(implementation = {extension(match_all)} \
-                               : parallel) default(parallel for)
+                               : parallel) otherwise(parallel for)
   for (int i = 0; i < 100; i++)
     ;
 #pragma omp metadirective when(implementation = {extension(match_any)} \
-                               : parallel) default(parallel for)
+                               : parallel) otherwise(parallel for)
   for (int i = 0; i < 100; i++)
     ;
 #pragma omp metadirective when(implementation = {extension(match_none)} \
-                               : parallel) default(parallel for)
+                               : parallel) otherwise(parallel for)
   for (int i = 0; i < 100; i++)
     ;
 }

--- a/clang/test/OpenMP/metadirective_implementation_codegen.cpp
+++ b/clang/test/OpenMP/metadirective_implementation_codegen.cpp
@@ -12,27 +12,27 @@ void foo() {
 #pragma omp metadirective when(implementation = {vendor(score(0)  \
                                                         : llvm)}, \
                                device = {kind(cpu)}               \
-                               : parallel) default(target teams)
+                               : parallel) otherwise(target teams)
   bar();
 #pragma omp metadirective when(device = {kind(gpu)}                                 \
                                : target teams) when(implementation = {vendor(llvm)} \
-                                                    : parallel) default()
+                                                    : parallel) otherwise()
   bar();
-#pragma omp metadirective default(target) when(implementation = {vendor(score(5)  \
+#pragma omp metadirective otherwise(target) when(implementation = {vendor(score(5)  \
                                                                         : llvm)}, \
                                                device = {kind(cpu, host)}         \
                                                : parallel)
   bar();
 #pragma omp metadirective when(implementation = {extension(match_all)} \
-                               : parallel) default(parallel for)
+                               : parallel) otherwise(parallel for)
   for (int i = 0; i < 100; i++)
     ;
 #pragma omp metadirective when(implementation = {extension(match_any)} \
-                               : parallel) default(parallel for)
+                               : parallel) otherwise(parallel for)
   for (int i = 0; i < 100; i++)
     ;
 #pragma omp metadirective when(implementation = {extension(match_none)} \
-                               : parallel) default(parallel for)
+                               : parallel) otherwise(parallel for)
   for (int i = 0; i < 100; i++)
     ;
 }

--- a/clang/test/OpenMP/metadirective_messages.cpp
+++ b/clang/test/OpenMP/metadirective_messages.cpp
@@ -11,12 +11,15 @@ void foo() {
   ;
 #pragma omp metadirective when(device{arch(nvptx)}) // expected-error {{missing ':' in when clause}} expected-error {{expected expression}} expected-warning {{expected '=' after the context set name "device"; '=' assumed}}
   ;
-#pragma omp metadirective when(device{arch(nvptx)}: ) default() // expected-warning {{expected '=' after the context set name "device"; '=' assumed}}
+#pragma omp metadirective when(device{arch(nvptx)}: ) otherwise() // expected-warning {{expected '=' after the context set name "device"; '=' assumed}}
   ;
-#pragma omp metadirective when(device = {arch(nvptx)} : ) default(xyz) // expected-error {{expected an OpenMP directive}} expected-error {{use of undeclared identifier 'xyz'}}
+#pragma omp metadirective when(device = {arch(nvptx)} : ) otherwise(xyz) // expected-error {{expected an OpenMP directive}} expected-error {{use of undeclared identifier 'xyz'}}
   ;
-#pragma omp metadirective when(device = {arch(nvptx)} : parallel default() // expected-error {{expected ',' or ')' in 'when' clause}} expected-error {{expected expression}}
+#pragma omp metadirective when(device = {arch(nvptx)} : parallel otherwise() // expected-error {{expected ',' or ')' in 'when' clause}} expected-error {{expected expression}}
   ;
-#pragma omp metadirective when(device = {isa("some-unsupported-feature")} : parallel) default(single) // expected-warning {{isa trait 'some-unsupported-feature' is not known to the current target; verify the spelling or consider restricting the context selector with the 'arch' selector further}}
+#pragma omp metadirective when(device = {isa("some-unsupported-feature")} : parallel) otherwise(single) // expected-warning {{isa trait 'some-unsupported-feature' is not known to the current target; verify the spelling or consider restricting the context selector with the 'arch' selector further}}
   ;
+#pragma omp metadirective when(device = {arch(nvptx)} : parallel) default() // expected-warning {{'default' clause for 'metadirective' is deprecated; use 'otherwise' instead}}
+  ;
+#pragma omp metadirective when(device = {arch(nvptx)} : parallel) xyz(); //expected-error {{unknown clause 'xyz' in metadirective}} expected-error {{use of undeclared identifier 'xyz'}} expected-error {{expected expression}}
 }

--- a/clang/test/OpenMP/metadirective_messages.cpp
+++ b/clang/test/OpenMP/metadirective_messages.cpp
@@ -21,5 +21,6 @@ void foo() {
   ;
 #pragma omp metadirective when(device = {arch(nvptx)} : parallel) default() // expected-warning {{'default' clause for 'metadirective' is deprecated; use 'otherwise' instead}}
   ;
-#pragma omp metadirective when(device = {arch(nvptx)} : parallel) xyz(); //expected-error {{unknown clause 'xyz' in metadirective}} expected-error {{use of undeclared identifier 'xyz'}} expected-error {{expected expression}}
+#pragma omp metadirective when(device = {arch(nvptx)} : parallel) xyz() //expected-error {{unknown clause 'xyz' in metadirective}} expected-error {{use of undeclared identifier 'xyz'}} expected-error {{expected expression}} expected-error {{expected ';' after expression}}
+  ;
 }

--- a/llvm/include/llvm/Frontend/OpenMP/OMP.td
+++ b/llvm/include/llvm/Frontend/OpenMP/OMP.td
@@ -525,6 +525,8 @@ def OMPC_Weak : Clause<"weak"> {
 }
 def OMPC_When: Clause<"when"> {
 }
+def OMPC_Otherwise: Clause<"otherwise"> {
+}
 def OMPC_Write : Clause<"write"> {
   let clangClass = "OMPWriteClause";
 }
@@ -843,6 +845,9 @@ def OMP_Master : Directive<"master"> {
 def OMP_Metadirective : Directive<"metadirective"> {
   let allowedClauses = [
     VersionedClause<OMPC_When>,
+  ];
+  let allowedClauses = [
+    VersionedClause<OMPC_Otherwise>,
   ];
   let allowedOnceClauses = [
     VersionedClause<OMPC_Default>,


### PR DESCRIPTION
This PR replaces the `default` clause with the `otherwise` clause for the `metadirective` in OpenMP. The `otherwise` clause serves as a fallback condition when no directive from the `when` clauses is selected. In the `when` clause, context selectors define traits evaluated to determine the directive to be applied.